### PR TITLE
Add dependency on message headers

### DIFF
--- a/dji_sdk/CMakeLists.txt
+++ b/dji_sdk/CMakeLists.txt
@@ -182,6 +182,9 @@ add_executable(dji_sdk_node
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
+add_dependencies(dji_sdk_geometry
+  dji_sdk_generate_messages_cpp)
+
 add_dependencies(dji_sdk_node
   dji_sdk_generate_messages_cpp)
 


### PR DESCRIPTION
The drone base build in GitHub Actions fails because a message header is not found when the new library `dji_sdk_geometry` is built. I think this will fix it.