### PR TITLE
DRONE-278 Only update GPS bias if RTK solution is healthy

### DIFF
--- a/dji_sdk/include/dji_sdk/dji_sdk_node.h
+++ b/dji_sdk/include/dji_sdk/dji_sdk_node.h
@@ -445,6 +445,7 @@ private:
   static int constexpr STABLE_ALIGNMENT_COUNT = 400;
   static double constexpr TIME_DIFF_CHECK = 0.008;
   static double constexpr TIME_DIFF_ALERT = 0.020;
+  static uint8_t constexpr RTK_FIX_THRESHOLD = 40;
 
   ros::Time base_time;
 

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -40,6 +40,11 @@ DJISDKNode::DJISDKNode(ros::NodeHandle& nh, ros::NodeHandle& nh_private)
   local_rtk_pos_ref_altitude  = 0;
   local_rtk_pos_ref_set       = false;
 
+  //! Initial values for GPS biases
+  bias_gps_latitude   = 0;
+  bias_gps_longitude  = 0;
+  bias_gps_altitude   = 0;
+
   //! RTK support check
   rtkSupport = false;
 
@@ -182,7 +187,7 @@ bool
 DJISDKNode::initFlightControl(ros::NodeHandle& nh)
 {
   flight_control_sub = nh.subscribe<sensor_msgs::Joy>(
-    "dji_sdk/flight_control_setpoint_generic", 10, 
+    "dji_sdk/flight_control_setpoint_generic", 10,
     &DJISDKNode::flightControlSetpointCallback,   this);
 
   flight_control_position_yaw_sub =
@@ -491,7 +496,7 @@ DJISDKNode::initDataSubscribeFromFC(ros::NodeHandle& nh)
     std::string hardwareVersion(vehicle->getHwVersion());
     if( (hardwareVersion == std::string(Version::N3)) || hardwareVersion == std::string(Version::A3))
     {
-      topicList50Hz.push_back(Telemetry::TOPIC_RC_FULL_RAW_DATA);      
+      topicList50Hz.push_back(Telemetry::TOPIC_RC_FULL_RAW_DATA);
     }
 
     // Advertise rc connection status only if this topic is supported by FW

--- a/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
@@ -366,11 +366,15 @@ DJISDKNode::publish5HzData(Vehicle *vehicle, RecvContainer recvFrame,
       local_rtk_pos_tf.transform.rotation.w = q_FLU2ENU.getW();
       br_rtk.sendTransform(local_rtk_pos_tf);
 
-      // Set the GPS bias (difference between RTK position and GPS position)
+      // Update the GPS bias (difference between RTK position and GPS position),
+      // if the RTK solution is healthy.
       // The bias is calculated as "bias = GPS - RTK" and should be used as "GPS_corrected = GPS - bias"
-      p->bias_gps_latitude = (fused_gps.latitude * 180.0 / C_PI) - p->current_rtk_latitude;
-      p->bias_gps_longitude = (fused_gps.longitude * 180.0 / C_PI) - p->current_rtk_longitude;
-      p->bias_gps_altitude = fused_altitude - p->current_rtk_altitude;
+      if (local_rtk_pos.solution_status > RTK_FIX_THRESHOLD)
+      {
+        p->bias_gps_latitude = (fused_gps.latitude * 180.0 / C_PI) - p->current_rtk_latitude;
+        p->bias_gps_longitude = (fused_gps.longitude * 180.0 / C_PI) - p->current_rtk_longitude;
+        p->bias_gps_altitude = fused_altitude - p->current_rtk_altitude;
+      }
     }
   }
 

--- a/dji_sdk/src/modules/dji_sdk_node_services.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_services.cpp
@@ -152,7 +152,7 @@ DJISDKNode::setLocalPosRefCallback(dji_sdk::SetLocalPosRef::Request &request,
   }
 
   printf("Currrent RTK health is %d \n",current_rtk_health );
-  if (current_rtk_health > 40) // TODO: Make parameter instead
+  if (current_rtk_health > RTK_FIX_THRESHOLD)
   {
     local_rtk_pos_ref_latitude = current_rtk_latitude;
     local_rtk_pos_ref_longitude = current_rtk_longitude;


### PR DESCRIPTION
Only update the GPS bias (relative to RTK) if the RTK position health is sufficient.