### PR TITLE
Log SDK control authority errors

### DIFF
--- a/dji_sdk/CMakeLists.txt
+++ b/dji_sdk/CMakeLists.txt
@@ -82,6 +82,7 @@ add_message_files(
   MissionHotpointTask.msg
   FlightAnomaly.msg
   UInt8Stamped.msg
+  UInt32Stamped.msg
   VOPosition.msg
   RTKYaw.msg
   RTKPosition.msg

--- a/dji_sdk/include/dji_sdk/dji_sdk_node.h
+++ b/dji_sdk/include/dji_sdk/dji_sdk_node.h
@@ -405,8 +405,8 @@ private:
   ros::Publisher time_sync_gps_utc_publisher;
   ros::Publisher time_sync_fc_utc_publisher;
   ros::Publisher time_sync_pps_source_publisher;
-  //! SDK control authority request ack error publisher
-  ros::Publisher control_authority_error_publisher;
+  //! SDK control authority request ack data publisher
+  ros::Publisher control_authority_ack_publisher;
 
 #ifdef ADVANCED_SENSING
   ros::Publisher stereo_240p_front_left_publisher;

--- a/dji_sdk/include/dji_sdk/dji_sdk_node.h
+++ b/dji_sdk/include/dji_sdk/dji_sdk_node.h
@@ -48,6 +48,7 @@
 #include <dji_sdk/GPSRaw.h>
 #include <dji_sdk/BaroHeight.h>
 #include <dji_sdk/UInt8Stamped.h>
+#include <dji_sdk/UInt32Stamped.h>
 #include <dji_sdk/DateTimeStamped.h>
 
 //! mission service
@@ -404,6 +405,8 @@ private:
   ros::Publisher time_sync_gps_utc_publisher;
   ros::Publisher time_sync_fc_utc_publisher;
   ros::Publisher time_sync_pps_source_publisher;
+  //! SDK control authority request ack error publisher
+  ros::Publisher control_authority_error_publisher;
 
 #ifdef ADVANCED_SENSING
   ros::Publisher stereo_240p_front_left_publisher;
@@ -469,6 +472,7 @@ private:
   void gpsConvertENU(double &ENU_x, double &ENU_y,
                      double gps_t_lon, double gps_t_lat,
                      double gps_r_lon, double gps_r_lat);
+  std::string controlAuthorityErrorString(const uint32_t error_code);
 
   double local_pos_ref_latitude, local_pos_ref_longitude, local_pos_ref_altitude;
   double current_gps_latitude, current_gps_longitude, current_gps_altitude;

--- a/dji_sdk/msg/UInt32Stamped.msg
+++ b/dji_sdk/msg/UInt32Stamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+uint32 data

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -338,8 +338,8 @@ DJISDKNode::initPublisher(ros::NodeHandle& nh)
   time_sync_pps_source_publisher =
       nh.advertise<std_msgs::String>("dji_sdk/time_sync_pps_source", 10);
 
-  control_authority_error_publisher =
-      nh.advertise<dji_sdk::UInt32Stamped>("dji_sdk/control_authority_error", 10);
+  control_authority_ack_publisher =
+      nh.advertise<dji_sdk::UInt32Stamped>("dji_sdk/control_authority_ack", 10);
 
 #ifdef ADVANCED_SENSING
   stereo_240p_front_left_publisher =

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -338,6 +338,9 @@ DJISDKNode::initPublisher(ros::NodeHandle& nh)
   time_sync_pps_source_publisher =
       nh.advertise<std_msgs::String>("dji_sdk/time_sync_pps_source", 10);
 
+  control_authority_error_publisher =
+      nh.advertise<dji_sdk::UInt32Stamped>("dji_sdk/control_authority_error", 10);
+
 #ifdef ADVANCED_SENSING
   stereo_240p_front_left_publisher =
     nh.advertise<sensor_msgs::Image>("dji_sdk/stereo_240p_front_left_images", 10);
@@ -724,3 +727,26 @@ void DJISDKNode::gpsConvertENU(double &ENU_x, double &ENU_y,
   ENU_y = DEG2RAD(d_lat) * C_EARTH;
   ENU_x = DEG2RAD(d_lon) * C_EARTH * cos(DEG2RAD(gps_t_lat));
 };
+
+std::string DJISDKNode::controlAuthorityErrorString(const uint32_t error_code)
+{
+  using ErrorCode = OpenProtocolCMD::ErrorCode::ControlACK::SetControl;
+  if (error_code == ErrorCode::RC_MODE_ERROR)
+    return "RC_MODE_ERROR";
+  else if (error_code == ErrorCode::RELEASE_CONTROL_SUCCESS)
+    return "RELEASE_CONTROL_SUCCESS";
+  else if (error_code == ErrorCode::OBTAIN_CONTROL_SUCCESS)
+    return "OBTAIN_CONTROL_SUCCESS";
+  else if (error_code == ErrorCode::OBTAIN_CONTROL_IN_PROGRESS)
+    return "OBTAIN_CONTROL_IN_PROGRESS";
+  else if (error_code == ErrorCode::RELEASE_CONTROL_IN_PROGRESS)
+    return "RELEASE_CONTROL_IN_PROGRESS";
+  else if (error_code == ErrorCode::RC_NEED_MODE_F)
+    return "RC_NEED_MODE_F";
+  else if (error_code == ErrorCode::RC_NEED_MODE_P)
+    return "RC_NEED_MODE_P";
+  else if (error_code == ErrorCode::IOC_OBTAIN_CONTROL_ERROR)
+    return "IOC_OBTAIN_CONTROL_ERROR";
+  else
+    return "";
+}

--- a/dji_sdk/src/modules/dji_sdk_node_services.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_services.cpp
@@ -112,6 +112,16 @@ DJISDKNode::sdkCtrlAuthorityCallback(
   {
     response.result = false;
     ACK::getErrorCodeMessage(ack, __func__);
+
+    dji_sdk::UInt32Stamped error_msg;
+    error_msg.header.stamp = ros::Time::now();
+    error_msg.data = ack.data;
+    control_authority_error_publisher.publish(error_msg);
+
+    ROS_ERROR(
+      "[dji_sdk] Control authority error: %s",
+      controlAuthorityErrorString(ack.data).c_str()
+    );
   }
   else
   {

--- a/dji_sdk/src/modules/dji_sdk_node_services.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_services.cpp
@@ -108,16 +108,15 @@ DJISDKNode::sdkCtrlAuthorityCallback(
   response.cmd_id   = (int)ack.info.cmd_id;
   response.ack_data = (unsigned int)ack.data;
 
+  dji_sdk::UInt32Stamped ack_data_msg;
+  ack_data_msg.header.stamp = ros::Time::now();
+  ack_data_msg.data = ack.data;
+  control_authority_ack_publisher.publish(ack_data_msg);
+
   if (ACK::getError(ack))
   {
     response.result = false;
     ACK::getErrorCodeMessage(ack, __func__);
-
-    dji_sdk::UInt32Stamped error_msg;
-    error_msg.header.stamp = ros::Time::now();
-    error_msg.data = ack.data;
-    control_authority_error_publisher.publish(error_msg);
-
     ROS_ERROR(
       "[dji_sdk] Control authority error: %s",
       controlAuthorityErrorString(ack.data).c_str()


### PR DESCRIPTION
Publish the error code if we fail to obtain SDK control, and print it to the console.
