### PR TITLE
Increase max time alignment attempts

### DIFF
--- a/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
@@ -890,7 +890,7 @@ void DJISDKNode::alignRosTimeWithFlightController(ros::Time now_time, uint32_t t
   {
     static int aligned_count = 0;
     static int retry_count = 0;
-    constexpr int MAX_RETRIES = 200;
+    constexpr int MAX_RETRIES = 500;
     ROS_INFO_THROTTLE(1.0, "[dji_sdk] Aligning time...");
 
     double dt = std::fabs((now_time - (base_time + _TICK2ROSTIME(tick))).toSec());


### PR DESCRIPTION
From the Elvia installations on November 8, it seemed like a maximum of 200 attempts to align time was too little.
